### PR TITLE
Copy analysis files

### DIFF
--- a/ruby/copy_analysis_files/README.md
+++ b/ruby/copy_analysis_files/README.md
@@ -1,16 +1,51 @@
-# Title
+# Copy output files of analyses recursively
 
-A short summary of your snippets
+It is useful if you have to compare results of some of parameter sets such as scaling analysis of cluster size distributions.
 
 ## Usage
 
-Usage of your snippets
+```
+./bin/oacis_ruby copy_analysis_files.rb <simulator name> <json> <directory>
+```
+
+You have to specify absolute paths of a json file and directory to copy files.
+
+`template.json` is a sample of the json file.
 
 ```
-./bin/oacis_ruby your_script.rb
+{
+  "constants": {
+    "x_length": 128,
+    "y_length": 128
+  },
+  "variables": [
+    {
+      "name": "fire_rate",
+      "short": "f"
+    },
+    {
+      "name": "pop_rate",
+      "short": "p"
+    }
+  ],
+  "analyzers": [
+    {
+      "name": "frequency_size_distribution",
+      "files": ["frequency_size_distribution.dat", "frequency_size_distribution.eps"]
+    },
+    {
+      "name": "waiting_time_distribution",
+      "files": ["waiting_time_distribution.dat", "waiting_time_distribution.eps"]
+    }
+  ]
+}
 ```
+
+The script search for parameter sets whose parameters specified by `constants` are fixed.
+Each file would copy to the directory `"<directory>/f#{fire_rate}/p#{pop_rate}/` in the case of the above example.
+Copied files are specified in the `analyzers` field.
 
 ## Author
 
-Your (account) name
+Naoki Yoshioka
 

--- a/ruby/copy_analysis_files/README.md
+++ b/ruby/copy_analysis_files/README.md
@@ -1,0 +1,16 @@
+# Title
+
+A short summary of your snippets
+
+## Usage
+
+Usage of your snippets
+
+```
+./bin/oacis_ruby your_script.rb
+```
+
+## Author
+
+Your (account) name
+

--- a/ruby/copy_analysis_files/copy_analysis_files.rb
+++ b/ruby/copy_analysis_files/copy_analysis_files.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'pathname'
+require 'fileutils'
+
+if ARGV.length != 3 then
+  $stderr.puts "wrong number of arguments: copy_analysis_files.rb <simulator name> <absolute path of json file> <absolute path of directory>"
+  exit(false)
+end
+
+simulator = Simulator.find_by_name(ARGV[0])
+copying_data_info = JSON.load(File.open(ARGV[1]))
+directory = Pathname(ARGV[2])
+
+constants = {}
+copying_data_info["constants"].each do |key, value|
+  constants["v.#{key}"] = value
+end
+variables = copying_data_info["variables"]
+
+copying_data_info["analyzers"].each do |analyzer_info|
+  analyzer_name = analyzer_info["name"]
+  analyzer = simulator.find_analyzer_by_name(analyzer_name)
+  $stdout.puts "[#{analyzer_name}]"
+
+  analyzer_files = analyzer_info["files"]
+
+  simulator.parameter_sets.where(constants).each do |parameter_set|
+    analyses = parameter_set.analyses.where(analyzer: analyzer, status: :finished)
+    next if analyses.length == 0
+    analysis = analyses.max_by {|analysis| analysis.created_at}
+
+    origins = analyzer_files.map {|filename| analysis.dir.join(filename)}
+    destination = variables.reduce(directory) {|result, variable| result.join("#{variable["short"]}#{parameter_set.v[variable["name"]]}")}
+
+    FileUtils.mkdir_p(destination)
+    $stdout.puts "copying to #{destination}"
+    origins.find_all {|origin| File.exist?(origin)}.each {|origin| FileUtils.cp(origin, destination)}
+  end
+end
+

--- a/ruby/copy_analysis_files/template.json
+++ b/ruby/copy_analysis_files/template.json
@@ -1,0 +1,26 @@
+{
+  "constants": {
+    "x_length": 128,
+    "y_length": 128
+  },
+  "variables": [
+    {
+      "name": "fire_rate",
+      "short": "f"
+    },
+    {
+      "name": "pop_rate",
+      "short": "p"
+    }
+  ],
+  "analyzers": [
+    {
+      "name": "frequency_size_distribution",
+      "files": ["frequency_size_distribution.dat", "frequency_size_distribution.eps"]
+    },
+    {
+      "name": "waiting_time_distribution",
+      "files": ["waiting_time_distribution.dat", "waiting_time_distribution.eps"]
+    }
+  ]
+}


### PR DESCRIPTION
サイズ分布などを比較したり、それらを纏めた図を作成する際には、Analysesにあるファイルをよそにコピーするのが便利だと思っています。
そのために使っているコードに手を加えて、特定のSimulatorに依存することなく使えるようにしたスクリプトを作りました。